### PR TITLE
feat: add reports dashboard UI

### DIFF
--- a/anddes-onboarding-frontend/src/app/app.component.html
+++ b/anddes-onboarding-frontend/src/app/app.component.html
@@ -24,6 +24,12 @@
             </button>
         </div>
         <br>
+        <div>
+            <button mat-button class="menu-button"  [routerLink]="['/reports']" routerLinkActive="active">
+                <span>REPORTES</span>
+            </button>
+        </div>
+        <br>
         <mat-tree [dataSource]="dataSource" [treeControl]="treeControl"  class="example-tree">
             <!-- This is the tree node template for leaf nodes -->
             <!-- There is inline padding applied to this node using styles.

--- a/anddes-onboarding-frontend/src/app/app.routes.ts
+++ b/anddes-onboarding-frontend/src/app/app.routes.ts
@@ -149,6 +149,11 @@ export const routes: Routes = [
       canActivate : [MsalGuard]
     },
     {
+      path: 'reports',
+      loadComponent: () => import('./components/reports/reports.component').then(mod => mod.ReportsComponent),
+      canActivate: [MsalGuard]
+    },
+    {
       path: 'login-failed',
       loadComponent: ()=> import('./components/login-failed/login-failed.component').then(mod => mod.LoginFailedComponent)
     }

--- a/anddes-onboarding-frontend/src/app/components/reports/dialogs/date-range-dialog.component.html
+++ b/anddes-onboarding-frontend/src/app/components/reports/dialogs/date-range-dialog.component.html
@@ -1,0 +1,20 @@
+<h2 mat-dialog-title>Selecciona el rango de fechas</h2>
+
+<mat-dialog-content>
+  <form [formGroup]="range" class="range-form">
+    <mat-form-field appearance="outline">
+      <mat-label>Rango</mat-label>
+      <mat-date-range-input [formGroup]="range" [rangePicker]="picker">
+        <input matStartDate matInput formControlName="start" placeholder="Desde" />
+        <input matEndDate matInput formControlName="end" placeholder="Hasta" />
+      </mat-date-range-input>
+      <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+      <mat-date-range-picker #picker></mat-date-range-picker>
+    </mat-form-field>
+  </form>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button type="button" (click)="cancel()">Cancelar</button>
+  <button mat-flat-button color="primary" type="button" (click)="apply()">Aplicar</button>
+</mat-dialog-actions>

--- a/anddes-onboarding-frontend/src/app/components/reports/dialogs/date-range-dialog.component.scss
+++ b/anddes-onboarding-frontend/src/app/components/reports/dialogs/date-range-dialog.component.scss
@@ -1,0 +1,15 @@
+.range-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 600px) {
+  .range-form {
+    flex-direction: row;
+  }
+
+  mat-form-field {
+    flex: 1;
+  }
+}

--- a/anddes-onboarding-frontend/src/app/components/reports/dialogs/date-range-dialog.component.ts
+++ b/anddes-onboarding-frontend/src/app/components/reports/dialogs/date-range-dialog.component.ts
@@ -1,0 +1,56 @@
+import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatDialogModule, MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatInputModule } from '@angular/material/input';
+import { provideNativeDateAdapter } from '@angular/material/core';
+
+export interface DateRangeSelection {
+  start: Date;
+  end: Date;
+}
+
+@Component({
+  selector: 'app-date-range-dialog',
+  standalone: true,
+  imports: [
+    MatDialogModule,
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatDatepickerModule,
+    MatInputModule,
+  ],
+  templateUrl: './date-range-dialog.component.html',
+  styleUrl: './date-range-dialog.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [provideNativeDateAdapter()],
+})
+export class DateRangeDialogComponent {
+  readonly range = new FormGroup({
+    start: new FormControl<Date | null>(this.data?.start ?? null),
+    end: new FormControl<Date | null>(this.data?.end ?? null),
+  });
+
+  constructor(
+    private readonly dialogRef: MatDialogRef<DateRangeDialogComponent, DateRangeSelection | undefined>,
+    @Inject(MAT_DIALOG_DATA) public readonly data: DateRangeSelection | undefined
+  ) {}
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+
+  apply(): void {
+    const start = this.range.value.start;
+    const end = this.range.value.end;
+
+    if (!start || !end) {
+      return;
+    }
+
+    this.dialogRef.close({ start, end });
+  }
+}

--- a/anddes-onboarding-frontend/src/app/components/reports/dialogs/elearning-detail-dialog.component.html
+++ b/anddes-onboarding-frontend/src/app/components/reports/dialogs/elearning-detail-dialog.component.html
@@ -1,0 +1,47 @@
+<h2 mat-dialog-title>Detalle e-learning - {{ data.fullName }}</h2>
+
+<mat-dialog-content>
+  <mat-progress-bar *ngIf="isLoading" mode="indeterminate"></mat-progress-bar>
+
+  <div class="error" *ngIf="hasError && !isLoading">
+    No fue posible cargar los cursos.
+  </div>
+
+  <div *ngIf="!isLoading && !hasError" class="table-wrapper">
+    <table mat-table [dataSource]="dataSource" class="mat-elevation-z1">
+      <ng-container matColumnDef="courseName">
+        <th mat-header-cell *matHeaderCellDef>Curso</th>
+        <td mat-cell *matCellDef="let row">{{ row.courseName }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="minimumScore">
+        <th mat-header-cell *matHeaderCellDef>Nota mínima</th>
+        <td mat-cell *matCellDef="let row">{{ row.minimumScore }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="score">
+        <th mat-header-cell *matHeaderCellDef>Calificación</th>
+        <td mat-cell *matCellDef="let row">{{ row.score }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="attempts">
+        <th mat-header-cell *matHeaderCellDef>Intentos</th>
+        <td mat-cell *matCellDef="let row">{{ row.attempts }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="status">
+        <th mat-header-cell *matHeaderCellDef>Estado</th>
+        <td mat-cell *matCellDef="let row">
+          <span [class]="statusClass(row)">{{ row.status }}</span>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button mat-dialog-close>Cerrar</button>
+</mat-dialog-actions>

--- a/anddes-onboarding-frontend/src/app/components/reports/dialogs/elearning-detail-dialog.component.scss
+++ b/anddes-onboarding-frontend/src/app/components/reports/dialogs/elearning-detail-dialog.component.scss
@@ -1,0 +1,38 @@
+.table-wrapper {
+  margin-top: 1rem;
+  max-height: 360px;
+  overflow: auto;
+}
+
+table {
+  width: 100%;
+}
+
+.status-chip {
+  display: inline-flex;
+  padding: 0.15rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.status-chip.completed {
+  color: #065f46;
+  background: #d1fae5;
+}
+
+.status-chip.pending {
+  color: #92400e;
+  background: #fef3c7;
+}
+
+.status-chip.in-progress {
+  color: #1d4ed8;
+  background: #dbeafe;
+}
+
+.error {
+  margin-top: 1rem;
+  color: #b91c1c;
+}

--- a/anddes-onboarding-frontend/src/app/components/reports/dialogs/elearning-detail-dialog.component.ts
+++ b/anddes-onboarding-frontend/src/app/components/reports/dialogs/elearning-detail-dialog.component.ts
@@ -1,0 +1,68 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatIconModule } from '@angular/material/icon';
+import { ReportService } from '../../../service/report.service';
+import { ElearningDetail } from '../../../entity/report';
+
+export interface ElearningDetailDialogData {
+  userId: string;
+  fullName: string;
+}
+
+@Component({
+  selector: 'app-elearning-detail-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule, MatTableModule, MatProgressBarModule, MatIconModule],
+  templateUrl: './elearning-detail-dialog.component.html',
+  styleUrl: './elearning-detail-dialog.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ElearningDetailDialogComponent implements OnInit {
+  readonly displayedColumns = ['courseName', 'minimumScore', 'score', 'attempts', 'status'];
+  readonly dataSource = new MatTableDataSource<ElearningDetail>([]);
+  isLoading = true;
+  hasError = false;
+
+  constructor(
+    private readonly reportService: ReportService,
+    private readonly cdr: ChangeDetectorRef,
+    private readonly dialogRef: MatDialogRef<ElearningDetailDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public readonly data: ElearningDetailDialogData
+  ) {}
+
+  ngOnInit(): void {
+    this.loadDetails();
+    this.dialogRef.updateSize('760px');
+  }
+
+  statusClass(detail: ElearningDetail): string {
+    const status = detail.status?.toLowerCase() ?? '';
+    if (status.includes('complet')) {
+      return 'status-chip completed';
+    }
+    if (status.includes('pend')) {
+      return 'status-chip pending';
+    }
+    return 'status-chip in-progress';
+  }
+
+  private loadDetails(): void {
+    this.reportService.getElearningDetail(this.data.userId).subscribe({
+      next: (details) => {
+        this.dataSource.data = details;
+        this.isLoading = false;
+        this.cdr.markForCheck();
+      },
+      error: () => {
+        this.dataSource.data = [];
+        this.isLoading = false;
+        this.hasError = true;
+        this.cdr.markForCheck();
+      },
+    });
+  }
+}

--- a/anddes-onboarding-frontend/src/app/components/reports/dialogs/general-detail-dialog.component.html
+++ b/anddes-onboarding-frontend/src/app/components/reports/dialogs/general-detail-dialog.component.html
@@ -1,0 +1,29 @@
+<h2 mat-dialog-title>Actividades - {{ data.fullName }}</h2>
+
+<mat-dialog-content>
+  <mat-progress-bar *ngIf="isLoading" mode="indeterminate"></mat-progress-bar>
+
+  <div class="error" *ngIf="hasError && !isLoading">
+    Ocurrió un error al cargar las actividades.
+  </div>
+
+  <div class="activities" *ngIf="!isLoading && !hasError">
+    <div class="activity" *ngFor="let activity of details" [class.completed]="activity.completed">
+      <mat-icon class="status-icon">{{ activity.completed ? 'check_circle' : 'radio_button_unchecked' }}</mat-icon>
+      <div class="activity-info">
+        <p class="title">{{ activity.title }}</p>
+        <p class="meta">
+          Responsable: {{ activity.responsible }}
+          <span class="dot" *ngIf="activity.completedAt">&bull;</span>
+          <ng-container *ngIf="activity.completedAt">
+            Finalizado el {{ activity.completedAt | date: 'shortDate' }}
+          </ng-container>
+        </p>
+      </div>
+    </div>
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button mat-dialog-close>Cerrar</button>
+</mat-dialog-actions>

--- a/anddes-onboarding-frontend/src/app/components/reports/dialogs/general-detail-dialog.component.scss
+++ b/anddes-onboarding-frontend/src/app/components/reports/dialogs/general-detail-dialog.component.scss
@@ -1,0 +1,55 @@
+.activities {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.activity {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 10px;
+  background: #f9fafb;
+  border: 1px solid transparent;
+
+  &.completed {
+    border-color: #d1fae5;
+    background: #ecfdf5;
+  }
+}
+
+.status-icon {
+  font-size: 24px;
+  color: #1d4ed8;
+
+  .activity.completed & {
+    color: #10b981;
+  }
+}
+
+.activity-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.meta {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.85rem;
+}
+
+.dot {
+  margin: 0 0.25rem;
+}
+
+.error {
+  margin-top: 1rem;
+  color: #b91c1c;
+}

--- a/anddes-onboarding-frontend/src/app/components/reports/dialogs/general-detail-dialog.component.ts
+++ b/anddes-onboarding-frontend/src/app/components/reports/dialogs/general-detail-dialog.component.ts
@@ -1,0 +1,55 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { ReportService } from '../../../service/report.service';
+import { ActivityDetail } from '../../../entity/report';
+
+export interface GeneralDetailDialogData {
+  userId: string;
+  fullName: string;
+}
+
+@Component({
+  selector: 'app-general-detail-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule, MatIconModule, MatProgressBarModule],
+  templateUrl: './general-detail-dialog.component.html',
+  styleUrl: './general-detail-dialog.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class GeneralDetailDialogComponent implements OnInit {
+  details: ActivityDetail[] = [];
+  isLoading = true;
+  hasError = false;
+
+  constructor(
+    private readonly reportService: ReportService,
+    private readonly cdr: ChangeDetectorRef,
+    private readonly dialogRef: MatDialogRef<GeneralDetailDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public readonly data: GeneralDetailDialogData
+  ) {}
+
+  ngOnInit(): void {
+    this.loadDetails();
+    this.dialogRef.updateSize('680px');
+  }
+
+  private loadDetails(): void {
+    this.reportService.getGeneralDetail(this.data.userId).subscribe({
+      next: (details) => {
+        this.details = details;
+        this.isLoading = false;
+        this.cdr.markForCheck();
+      },
+      error: () => {
+        this.details = [];
+        this.isLoading = false;
+        this.hasError = true;
+        this.cdr.markForCheck();
+      },
+    });
+  }
+}

--- a/anddes-onboarding-frontend/src/app/components/reports/reports.component.html
+++ b/anddes-onboarding-frontend/src/app/components/reports/reports.component.html
@@ -1,0 +1,165 @@
+<div class="reports-page">
+  <div class="filters">
+    <mat-form-field appearance="outline">
+      <mat-label>Tipo de reporte</mat-label>
+      <mat-select [formControl]="typeControl">
+        <mat-option *ngFor="let option of reportTypes" [value]="option.value">
+          {{ option.label }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline">
+      <mat-label>Periodo</mat-label>
+      <mat-select [formControl]="periodControl">
+        <mat-option *ngFor="let option of periodOptions" [value]="option.value">
+          {{ option.label }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline">
+      <mat-label>Estado</mat-label>
+      <mat-select [formControl]="stateControl">
+        <mat-option *ngFor="let option of stateOptions" [value]="option.value">
+          {{ option.label }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field class="search-field" appearance="outline">
+      <mat-label>Buscar por usuario</mat-label>
+      <input matInput [formControl]="searchControl" placeholder="Nombre o correo" />
+      <button
+        mat-icon-button
+        matSuffix
+        type="button"
+        aria-label="Limpiar búsqueda"
+        *ngIf="searchControl.value"
+        (click)="clearSearch()"
+      >
+        <mat-icon>close</mat-icon>
+      </button>
+    </mat-form-field>
+
+    <button mat-stroked-button color="primary" class="download-button" type="button" (click)="downloadExcel()">
+      <mat-icon>file_download</mat-icon>
+      Descargar Excel
+    </button>
+  </div>
+
+  <mat-progress-bar *ngIf="isLoading" mode="indeterminate"></mat-progress-bar>
+
+  <div class="table-wrapper">
+    <table
+      mat-table
+      [dataSource]="dataSource"
+      matSort
+      matSortActive="fullName"
+      matSortDisableClear
+      matSortDirection="asc"
+      class="mat-elevation-z1"
+    >
+      <ng-container matColumnDef="fullName">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Usuario</th>
+        <td mat-cell *matCellDef="let row">{{ row.fullName }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="position" *ngIf="isGeneral || isMatrix">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Cargo</th>
+        <td mat-cell *matCellDef="let row">{{ row.position }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="bossName" *ngIf="isGeneral">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Jefe</th>
+        <td mat-cell *matCellDef="let row">{{ row.bossName }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="progress" *ngIf="isGeneral">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Avance</th>
+        <td mat-cell *matCellDef="let row">
+          <div class="progress-cell">
+            <span class="progress-value">{{ row.progress | number: '1.0-0' }}%</span>
+            <span class="progress-label">{{ getProgressLabel(row) }}</span>
+          </div>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="state" *ngIf="isGeneral || isElearning">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Estado</th>
+        <td mat-cell *matCellDef="let row">
+          <span [class]="stateClass(resolveState(row))">{{ stateLabel(resolveState(row)) }}</span>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="startDate" *ngIf="isGeneral">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Fecha de inicio</th>
+        <td mat-cell *matCellDef="let row">{{ row.startDate | date: 'shortDate' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="totalCourses" *ngIf="isElearning">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Cursos</th>
+        <td mat-cell *matCellDef="let row">{{ row.totalCourses }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="approvedCourses" *ngIf="isElearning">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Completados</th>
+        <td mat-cell *matCellDef="let row">{{ row.approvedCourses }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="averageScore" *ngIf="isElearning">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Promedio</th>
+        <td mat-cell *matCellDef="let row">{{ row.averageScore | number: '1.0-1' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="updatedAt" *ngIf="isElearning || isMatrix">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Actualizado</th>
+        <td mat-cell *matCellDef="let row">{{ row.updatedAt | date: 'short' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="area" *ngIf="isMatrix">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>\u00c1rea</th>
+        <td mat-cell *matCellDef="let row">{{ row.area }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="matrixStatus" *ngIf="isMatrix">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Estado matriz</th>
+        <td mat-cell *matCellDef="let row">{{ row.matrixStatus }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="actions" *ngIf="isGeneral || isElearning">
+        <th mat-header-cell *matHeaderCellDef class="actions-header">Acciones</th>
+        <td mat-cell *matCellDef="let row" class="actions-cell">
+          <button
+            mat-stroked-button
+            color="primary"
+            type="button"
+            *ngIf="isGeneral"
+            (click)="openGeneralDetail(row)"
+          >
+            <mat-icon>checklist</mat-icon>
+            Actividades
+          </button>
+          <button
+            mat-stroked-button
+            color="primary"
+            type="button"
+            *ngIf="isElearning"
+            (click)="openElearningDetail(row)"
+          >
+            <mat-icon>school</mat-icon>
+            Detalle
+          </button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns" class="data-row"></tr>
+      <tr class="mat-row" *matNoDataRow>
+        <td class="no-data" [attr.colspan]="displayedColumns.length">No se encontraron resultados</td>
+      </tr>
+    </table>
+
+    <mat-paginator [length]="resultsLength" [pageSize]="10" [pageSizeOptions]="[10, 25, 50]"></mat-paginator>
+  </div>
+</div>

--- a/anddes-onboarding-frontend/src/app/components/reports/reports.component.scss
+++ b/anddes-onboarding-frontend/src/app/components/reports/reports.component.scss
@@ -1,0 +1,120 @@
+.reports-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 1rem;
+
+  mat-form-field {
+    min-width: 220px;
+  }
+
+  .search-field {
+    flex: 1 1 260px;
+  }
+
+  .download-button {
+    align-self: center;
+    display: inline-flex;
+    gap: 0.25rem;
+  }
+}
+
+.table-wrapper {
+  background-color: #fff;
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: 0 10px 30px -15px rgba(0, 0, 0, 0.3);
+}
+
+table {
+  width: 100%;
+}
+
+.progress-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+
+  .progress-value {
+    font-weight: 600;
+  }
+
+  .progress-label {
+    font-size: 0.75rem;
+    color: #6b7280;
+  }
+}
+
+.actions-header,
+.actions-cell {
+  text-align: right;
+}
+
+.actions-cell {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.15rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.status-pending {
+  color: #92400e;
+  background-color: #fef3c7;
+}
+
+.status-completed {
+  color: #065f46;
+  background-color: #d1fae5;
+}
+
+.status-progress {
+  color: #1d4ed8;
+  background-color: #dbeafe;
+}
+
+.no-data {
+  text-align: center;
+  padding: 1.5rem 0;
+  color: #6b7280;
+}
+
+@media (max-width: 900px) {
+  .filters {
+    flex-direction: column;
+    align-items: stretch;
+
+    mat-form-field,
+    .download-button {
+      width: 100%;
+    }
+
+    .download-button {
+      justify-content: center;
+    }
+  }
+
+  .actions-cell {
+    flex-direction: column;
+    align-items: stretch;
+
+    button {
+      width: 100%;
+    }
+  }
+}

--- a/anddes-onboarding-frontend/src/app/components/reports/reports.component.ts
+++ b/anddes-onboarding-frontend/src/app/components/reports/reports.component.ts
@@ -1,0 +1,352 @@
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatDialog } from '@angular/material/dialog';
+import { Subject, startWith, switchMap, tap, throwError } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, map } from 'rxjs/operators';
+import {
+  ElearningReportRow,
+  GeneralReportRow,
+  MatrixReportRow,
+  ReportQuery,
+  ReportRowState,
+  ReportStateFilter,
+  ReportType,
+} from '../../entity/report';
+import { ReportService } from '../../service/report.service';
+import { DateRangeDialogComponent, DateRangeSelection } from './dialogs/date-range-dialog.component';
+import { GeneralDetailDialogComponent } from './dialogs/general-detail-dialog.component';
+import { ElearningDetailDialogComponent } from './dialogs/elearning-detail-dialog.component';
+
+type ReportPeriod = '3m' | '1m' | 'custom';
+
+@Component({
+  selector: 'app-reports',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    MatInputModule,
+    MatIconModule,
+    MatButtonModule,
+    MatTableModule,
+    MatSortModule,
+    MatPaginatorModule,
+    MatProgressBarModule,
+  ],
+  templateUrl: './reports.component.html',
+  styleUrl: './reports.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ReportsComponent implements AfterViewInit {
+  readonly typeControl = new FormControl<ReportType>('general', { nonNullable: true });
+  readonly periodControl = new FormControl<ReportPeriod>('3m', { nonNullable: true });
+  readonly stateControl = new FormControl<ReportStateFilter>('all', { nonNullable: true });
+  readonly searchControl = new FormControl<string>('', { nonNullable: true });
+
+  readonly reportTypes = [
+    { value: 'general' as ReportType, label: 'General' },
+    { value: 'elearning' as ReportType, label: 'Inducci\u00f3n e-learning' },
+    { value: 'matrix' as ReportType, label: 'Matriz' },
+  ];
+
+  readonly periodOptions = [
+    { value: '3m' as ReportPeriod, label: '3 meses' },
+    { value: '1m' as ReportPeriod, label: '\u00daltimo mes' },
+    { value: 'custom' as ReportPeriod, label: 'Rango de fechas' },
+  ];
+
+  readonly stateOptions = [
+    { value: 'all' as ReportStateFilter, label: 'Todos' },
+    { value: 'pending' as ReportStateFilter, label: 'Pendientes' },
+    { value: 'completed' as ReportStateFilter, label: 'Completados' },
+  ];
+
+  readonly dataSource = new MatTableDataSource<any>([]);
+  displayedColumns: string[] = [];
+  resultsLength = 0;
+  isLoading = false;
+
+  private readonly load$ = new Subject<void>();
+  private customRange?: DateRangeSelection;
+  private lastPeriod: ReportPeriod = '3m';
+  private currentType: ReportType = this.typeControl.value;
+
+  @ViewChild(MatSort) sort!: MatSort;
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+
+  constructor(
+    private readonly reportService: ReportService,
+    private readonly dialog: MatDialog,
+    private readonly cdr: ChangeDetectorRef
+  ) {
+    this.updateDisplayedColumns(this.currentType);
+  }
+
+  ngAfterViewInit(): void {
+    this.sort.sortChange.subscribe(() => {
+      this.resetPaginator();
+      this.load$.next();
+    });
+
+    this.paginator.page.subscribe(() => this.load$.next());
+
+    this.typeControl.valueChanges.subscribe((type) => {
+      this.currentType = type;
+      this.updateDisplayedColumns(type);
+      this.resetPaginator();
+      this.load$.next();
+    });
+
+    this.stateControl.valueChanges.subscribe(() => {
+      this.resetPaginator();
+      this.load$.next();
+    });
+
+    this.periodControl.valueChanges.subscribe((period) => {
+      if (period === 'custom') {
+        this.openDateRangeDialog();
+      } else {
+        this.customRange = undefined;
+        this.lastPeriod = period;
+        this.resetPaginator();
+        this.load$.next();
+      }
+    });
+
+    this.searchControl.valueChanges
+      .pipe(debounceTime(400), distinctUntilChanged())
+      .subscribe(() => {
+        this.resetPaginator();
+        this.load$.next();
+      });
+
+    this.load$
+      .pipe(
+        startWith(void 0),
+        tap(() => {
+          this.isLoading = true;
+          this.cdr.markForCheck();
+        }),
+        switchMap(() =>
+          this.loadReportData().pipe(
+            catchError((error) => {
+              this.isLoading = false;
+              this.cdr.markForCheck();
+              return throwError(() => error);
+            })
+          )
+        )
+      )
+      .subscribe({
+        next: () => {
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  get isGeneral(): boolean {
+    return this.currentType === 'general';
+  }
+
+  get isElearning(): boolean {
+    return this.currentType === 'elearning';
+  }
+
+  get isMatrix(): boolean {
+    return this.currentType === 'matrix';
+  }
+
+  clearSearch(): void {
+    this.searchControl.setValue('');
+  }
+
+  downloadExcel(): void {
+    const query = this.buildQuery();
+    this.reportService.downloadReport(this.currentType, query).subscribe((blob) => {
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `reporte-${this.currentType}.xlsx`;
+      anchor.click();
+      URL.revokeObjectURL(url);
+    });
+  }
+
+  openGeneralDetail(row: any): void {
+    const generalRow = row as GeneralReportRow;
+    this.dialog.open(GeneralDetailDialogComponent, {
+      data: { userId: generalRow.id, fullName: generalRow.fullName },
+    });
+  }
+
+  openElearningDetail(row: any): void {
+    const elearningRow = row as ElearningReportRow;
+    this.dialog.open(ElearningDetailDialogComponent, {
+      data: { userId: elearningRow.id, fullName: elearningRow.fullName },
+    });
+  }
+
+  getProgressLabel(row: any): string {
+    const general = row as GeneralReportRow;
+    return `${general.completedActivities}/${general.totalActivities}`;
+  }
+
+  stateLabel(state: ReportRowState): string {
+    switch (state) {
+      case 'completed':
+        return 'Completado';
+      case 'pending':
+        return 'Pendiente';
+      case 'in_progress':
+        return 'En progreso';
+      default:
+        return state;
+    }
+  }
+
+  stateClass(state: ReportRowState): string {
+    switch (state) {
+      case 'completed':
+        return 'status-pill status-completed';
+      case 'pending':
+        return 'status-pill status-pending';
+      case 'in_progress':
+      default:
+        return 'status-pill status-progress';
+    }
+  }
+
+  resolveState(row: any): ReportRowState {
+    const value = (row as GeneralReportRow).state ?? (row as ElearningReportRow).state;
+    return (value ?? 'pending') as ReportRowState;
+  }
+
+  private loadReportData() {
+    const query = this.buildQuery();
+    switch (this.currentType) {
+      case 'general':
+        return this.reportService.getGeneralReport(query).pipe(
+          tap((response) => {
+            this.resultsLength = response.total;
+            this.dataSource.data = response.data;
+            this.cdr.markForCheck();
+          }),
+          map(() => void 0)
+        );
+      case 'elearning':
+        return this.reportService.getElearningReport(query).pipe(
+          tap((response) => {
+            this.resultsLength = response.total;
+            this.dataSource.data = response.data;
+            this.cdr.markForCheck();
+          }),
+          map(() => void 0)
+        );
+      case 'matrix':
+      default:
+        return this.reportService.getMatrixReport(query).pipe(
+          tap((response) => {
+            this.resultsLength = response.total;
+            this.dataSource.data = response.data;
+            this.cdr.markForCheck();
+          }),
+          map(() => void 0)
+        );
+    }
+  }
+
+  private buildQuery(): ReportQuery {
+    const { startDate, endDate } = this.resolveDates();
+    const direction = this.sort?.direction ? (this.sort.direction as 'asc' | 'desc') : undefined;
+
+    return {
+      state: this.stateControl.value,
+      search: this.searchControl.value?.trim() || undefined,
+      startDate,
+      endDate,
+      orderBy: this.sort?.active,
+      direction,
+      pageIndex: this.paginator?.pageIndex ?? 0,
+      pageSize: this.paginator?.pageSize ?? 10,
+    };
+  }
+
+  private resolveDates(): { startDate?: string; endDate?: string } {
+    const now = new Date();
+    const end = now.toISOString();
+
+    if (this.periodControl.value === '1m') {
+      const start = new Date();
+      start.setMonth(start.getMonth() - 1);
+      return { startDate: start.toISOString(), endDate: end };
+    }
+
+    if (this.periodControl.value === '3m') {
+      const start = new Date();
+      start.setMonth(start.getMonth() - 3);
+      return { startDate: start.toISOString(), endDate: end };
+    }
+
+    if (this.customRange?.start && this.customRange?.end) {
+      return {
+        startDate: this.customRange.start.toISOString(),
+        endDate: this.customRange.end.toISOString(),
+      };
+    }
+
+    return {};
+  }
+
+  private resetPaginator(): void {
+    if (this.paginator) {
+      this.paginator.firstPage();
+    }
+  }
+
+  private updateDisplayedColumns(type: ReportType): void {
+    if (type === 'general') {
+      this.displayedColumns = ['fullName', 'position', 'bossName', 'progress', 'state', 'startDate', 'actions'];
+    } else if (type === 'elearning') {
+      this.displayedColumns = ['fullName', 'totalCourses', 'approvedCourses', 'averageScore', 'state', 'updatedAt', 'actions'];
+    } else {
+      this.displayedColumns = ['fullName', 'area', 'position', 'matrixStatus', 'updatedAt'];
+    }
+  }
+
+  private openDateRangeDialog(): void {
+    const dialogRef = this.dialog.open<DateRangeDialogComponent, DateRangeSelection | undefined, DateRangeSelection>(
+      DateRangeDialogComponent,
+      {
+        data: this.customRange,
+      }
+    );
+
+    dialogRef.afterClosed().subscribe((range) => {
+      if (range) {
+        this.customRange = range;
+        this.lastPeriod = 'custom';
+        this.resetPaginator();
+        this.load$.next();
+      } else {
+        this.periodControl.setValue(this.lastPeriod, { emitEvent: false });
+      }
+    });
+  }
+}

--- a/anddes-onboarding-frontend/src/app/entity/report.ts
+++ b/anddes-onboarding-frontend/src/app/entity/report.ts
@@ -1,0 +1,69 @@
+export type ReportType = 'general' | 'elearning' | 'matrix';
+
+export type ReportStateFilter = 'all' | 'pending' | 'completed';
+
+export interface ReportQuery {
+  state: ReportStateFilter;
+  search?: string;
+  startDate?: string;
+  endDate?: string;
+  orderBy?: string;
+  direction?: 'asc' | 'desc';
+  pageIndex: number;
+  pageSize: number;
+}
+
+export interface PagedReportResponse<T> {
+  total: number;
+  data: T[];
+}
+
+export type ReportRowState = 'pending' | 'in_progress' | 'completed';
+
+export interface GeneralReportRow {
+  id: string;
+  fullName: string;
+  position: string;
+  bossName: string;
+  startDate: string;
+  progress: number;
+  state: ReportRowState;
+  completedActivities: number;
+  totalActivities: number;
+}
+
+export interface ElearningReportRow {
+  id: string;
+  fullName: string;
+  totalCourses: number;
+  approvedCourses: number;
+  averageScore: number;
+  state: ReportRowState;
+  updatedAt: string;
+}
+
+export interface MatrixReportRow {
+  id: string;
+  fullName: string;
+  area: string;
+  position: string;
+  matrixStatus: string;
+  updatedAt: string;
+}
+
+export interface ActivityDetail {
+  id: string;
+  title: string;
+  responsible: string;
+  completed: boolean;
+  completedAt?: string;
+}
+
+export interface ElearningDetail {
+  id: string;
+  courseName: string;
+  minimumScore: number;
+  score: number;
+  attempts: number;
+  status: string;
+}

--- a/anddes-onboarding-frontend/src/app/service/report.service.ts
+++ b/anddes-onboarding-frontend/src/app/service/report.service.ts
@@ -1,0 +1,85 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+import {
+  ActivityDetail,
+  ElearningDetail,
+  ElearningReportRow,
+  GeneralReportRow,
+  MatrixReportRow,
+  PagedReportResponse,
+  ReportQuery,
+  ReportType,
+} from '../entity/report';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ReportService {
+  private readonly baseUrl = `${environment.baseUrl}reports`;
+
+  constructor(private readonly httpClient: HttpClient) {}
+
+  getGeneralReport(query: ReportQuery): Observable<PagedReportResponse<GeneralReportRow>> {
+    return this.httpClient.get<PagedReportResponse<GeneralReportRow>>(
+      `${this.baseUrl}/general`,
+      { params: this.buildParams('general', query) }
+    );
+  }
+
+  getElearningReport(query: ReportQuery): Observable<PagedReportResponse<ElearningReportRow>> {
+    return this.httpClient.get<PagedReportResponse<ElearningReportRow>>(
+      `${this.baseUrl}/elearning`,
+      { params: this.buildParams('elearning', query) }
+    );
+  }
+
+  getMatrixReport(query: ReportQuery): Observable<PagedReportResponse<MatrixReportRow>> {
+    return this.httpClient.get<PagedReportResponse<MatrixReportRow>>(
+      `${this.baseUrl}/matrix`,
+      { params: this.buildParams('matrix', query) }
+    );
+  }
+
+  getGeneralDetail(userId: string): Observable<ActivityDetail[]> {
+    return this.httpClient.get<ActivityDetail[]>(`${this.baseUrl}/general/${userId}`);
+  }
+
+  getElearningDetail(userId: string): Observable<ElearningDetail[]> {
+    return this.httpClient.get<ElearningDetail[]>(`${this.baseUrl}/elearning/${userId}`);
+  }
+
+  downloadReport(type: ReportType, query: ReportQuery): Observable<Blob> {
+    return this.httpClient.get(`${this.baseUrl}/download`, {
+      params: this.buildParams(type, query),
+      responseType: 'blob',
+    });
+  }
+
+  private buildParams(type: ReportType, query: ReportQuery): HttpParams {
+    let params = new HttpParams()
+      .set('type', type)
+      .set('state', query.state)
+      .set('page', query.pageIndex + 1)
+      .set('pageSize', query.pageSize);
+
+    if (query.search) {
+      params = params.set('filter', query.search);
+    }
+    if (query.startDate) {
+      params = params.set('startDate', query.startDate);
+    }
+    if (query.endDate) {
+      params = params.set('endDate', query.endDate);
+    }
+    if (query.orderBy) {
+      params = params.set('orderBy', query.orderBy);
+    }
+    if (query.direction) {
+      params = params.set('direction', query.direction);
+    }
+
+    return params;
+  }
+}


### PR DESCRIPTION
## Summary
- add a sidenav entry and guarded route for the new reports area
- implement a standalone reports component with filters, paginated tables, Excel export, and detail dialogs
- create typed report entities and a service to call the backend endpoints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6a3d06a6883319e3628355b9e3051