### PR TITLE
feat: display formatted custom period labels

### DIFF
--- a/anddes-onboarding-frontend/src/app/components/reports/reports.component.html
+++ b/anddes-onboarding-frontend/src/app/components/reports/reports.component.html
@@ -12,6 +12,9 @@
     <mat-form-field appearance="outline">
       <mat-label>Periodo</mat-label>
       <mat-select [formControl]="periodControl">
+        <mat-select-trigger>
+          {{ formatPeriodLabel() }}
+        </mat-select-trigger>
         <mat-option *ngFor="let option of periodOptions" [value]="option.value">
           {{ option.label }}
         </mat-option>

--- a/anddes-onboarding-frontend/src/app/components/reports/reports.component.ts
+++ b/anddes-onboarding-frontend/src/app/components/reports/reports.component.ts
@@ -82,6 +82,11 @@ export class ReportsComponent implements AfterViewInit {
   private customRange?: DateRangeSelection;
   private lastPeriod: ReportPeriod = '3m';
   private currentType: ReportType = this.typeControl.value;
+  private readonly dateFormatter = new Intl.DateTimeFormat('es-PE', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
 
   @ViewChild(MatSort) sort!: MatSort;
   @ViewChild(MatPaginator) paginator!: MatPaginator;
@@ -206,6 +211,19 @@ export class ReportsComponent implements AfterViewInit {
   getProgressLabel(row: any): string {
     const general = row as GeneralReportRow;
     return `${general.completedActivities}/${general.totalActivities}`;
+  }
+
+  formatPeriodLabel(): string {
+    const period = this.periodControl.value;
+
+    if (period === 'custom' && this.customRange?.start && this.customRange?.end) {
+      const startLabel = this.dateFormatter.format(this.customRange.start);
+      const endLabel = this.dateFormatter.format(this.customRange.end);
+      return `${startLabel} - ${endLabel}`;
+    }
+
+    const option = this.periodOptions.find((item) => item.value === period);
+    return option?.label ?? '';
   }
 
   stateLabel(state: ReportRowState): string {
@@ -339,6 +357,8 @@ export class ReportsComponent implements AfterViewInit {
     );
 
     dialogRef.afterClosed().subscribe((range) => {
+      const previousLabel = this.formatPeriodLabel();
+
       if (range) {
         this.customRange = range;
         this.lastPeriod = 'custom';
@@ -346,6 +366,11 @@ export class ReportsComponent implements AfterViewInit {
         this.load$.next();
       } else {
         this.periodControl.setValue(this.lastPeriod, { emitEvent: false });
+      }
+
+      const currentLabel = this.formatPeriodLabel();
+      if (currentLabel !== previousLabel) {
+        this.cdr.markForCheck();
       }
     });
   }


### PR DESCRIPTION
## Summary
- add a period label formatter to present custom ranges with localized dates
- render the formatted value inside the period selector trigger
- notify change detection when the custom range label changes after closing the dialog

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d706e70d348331824d18158ccaa82c