### PR TITLE
Add support for relative report periods

### DIFF
--- a/anddes-onboarding-backend/src/main/java/pe/compendio/myandess/onboarding/controller/ReportController.java
+++ b/anddes-onboarding-backend/src/main/java/pe/compendio/myandess/onboarding/controller/ReportController.java
@@ -157,7 +157,21 @@ public class ReportController {
     if (StringUtils.hasText(period)) {
       period = period.trim();
       try {
-        if (period.matches("\\d{4}-\\d{2}")) {
+        if ("3m".equalsIgnoreCase(period)) {
+          LocalDate today = LocalDate.now();
+          start = today.minusMonths(3);
+          end = today;
+        } else if ("1m".equalsIgnoreCase(period)) {
+          LocalDate today = LocalDate.now();
+          start = today.minusMonths(1);
+          end = today;
+        } else if ("custom".equalsIgnoreCase(period)) {
+          if (!StringUtils.hasText(startDate) || !StringUtils.hasText(endDate)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Fechas requeridas para periodo personalizado");
+          }
+          start = LocalDate.parse(startDate.trim());
+          end = LocalDate.parse(endDate.trim());
+        } else if (period.matches("\\d{4}-\\d{2}")) {
           YearMonth yearMonth = YearMonth.parse(period);
           start = yearMonth.atDay(1);
           end = yearMonth.atEndOfMonth();

--- a/anddes-onboarding-backend/src/test/java/pe/compendio/myandess/onboarding/controller/ReportControllerTest.java
+++ b/anddes-onboarding-backend/src/test/java/pe/compendio/myandess/onboarding/controller/ReportControllerTest.java
@@ -2,6 +2,7 @@ package pe.compendio.myandess.onboarding.controller;
 
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -16,12 +17,14 @@ import pe.compendio.myandess.onboarding.service.ReportService;
 import java.time.LocalDate;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -86,5 +89,80 @@ class ReportControllerTest {
       .andExpect(status().isOk())
       .andExpect(header().string("Content-Disposition", containsString("report-general")))
       .andExpect(content().contentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")));
+  }
+
+  @Test
+  void generalReportShouldRespectThreeMonthPeriod() throws Exception {
+    ReportPagedDTO<ReportGeneralRowDTO> paged = new ReportPagedDTO<>(0, List.of());
+    when(reportService.getGeneralReport(any(LocalDate.class), any(LocalDate.class), nullable(String.class), nullable(String.class), anyInt(), anyInt(), anyString(), anyString()))
+      .thenReturn(paged);
+
+    LocalDate today = LocalDate.now();
+    LocalDate expectedStart = today.minusMonths(3);
+    LocalDate expectedEnd = today;
+
+    mockMvc.perform(get("/reports/general")
+        .param("period", "3m"))
+      .andExpect(status().isOk());
+
+    ArgumentCaptor<LocalDate> startCaptor = ArgumentCaptor.forClass(LocalDate.class);
+    ArgumentCaptor<LocalDate> endCaptor = ArgumentCaptor.forClass(LocalDate.class);
+
+    verify(reportService).getGeneralReport(startCaptor.capture(), endCaptor.capture(), nullable(String.class), nullable(String.class), anyInt(), anyInt(), anyString(), anyString());
+
+    assertThat(startCaptor.getValue()).isEqualTo(expectedStart);
+    assertThat(endCaptor.getValue()).isEqualTo(expectedEnd);
+  }
+
+  @Test
+  void generalReportShouldRespectOneMonthPeriod() throws Exception {
+    ReportPagedDTO<ReportGeneralRowDTO> paged = new ReportPagedDTO<>(0, List.of());
+    when(reportService.getGeneralReport(any(LocalDate.class), any(LocalDate.class), nullable(String.class), nullable(String.class), anyInt(), anyInt(), anyString(), anyString()))
+      .thenReturn(paged);
+
+    LocalDate today = LocalDate.now();
+    LocalDate expectedStart = today.minusMonths(1);
+    LocalDate expectedEnd = today;
+
+    mockMvc.perform(get("/reports/general")
+        .param("period", "1m"))
+      .andExpect(status().isOk());
+
+    ArgumentCaptor<LocalDate> startCaptor = ArgumentCaptor.forClass(LocalDate.class);
+    ArgumentCaptor<LocalDate> endCaptor = ArgumentCaptor.forClass(LocalDate.class);
+
+    verify(reportService).getGeneralReport(startCaptor.capture(), endCaptor.capture(), nullable(String.class), nullable(String.class), anyInt(), anyInt(), anyString(), anyString());
+
+    assertThat(startCaptor.getValue()).isEqualTo(expectedStart);
+    assertThat(endCaptor.getValue()).isEqualTo(expectedEnd);
+  }
+
+  @Test
+  void generalReportShouldUseCustomDatesWhenPeriodIsCustom() throws Exception {
+    ReportPagedDTO<ReportGeneralRowDTO> paged = new ReportPagedDTO<>(0, List.of());
+    when(reportService.getGeneralReport(any(LocalDate.class), any(LocalDate.class), nullable(String.class), nullable(String.class), anyInt(), anyInt(), anyString(), anyString()))
+      .thenReturn(paged);
+
+    mockMvc.perform(get("/reports/general")
+        .param("period", "custom")
+        .param("startDate", "2024-03-01")
+        .param("endDate", "2024-03-31"))
+      .andExpect(status().isOk());
+
+    ArgumentCaptor<LocalDate> startCaptor = ArgumentCaptor.forClass(LocalDate.class);
+    ArgumentCaptor<LocalDate> endCaptor = ArgumentCaptor.forClass(LocalDate.class);
+
+    verify(reportService).getGeneralReport(startCaptor.capture(), endCaptor.capture(), nullable(String.class), nullable(String.class), anyInt(), anyInt(), anyString(), anyString());
+
+    assertThat(startCaptor.getValue()).isEqualTo(LocalDate.of(2024, 3, 1));
+    assertThat(endCaptor.getValue()).isEqualTo(LocalDate.of(2024, 3, 31));
+  }
+
+  @Test
+  void generalReportShouldReturnBadRequestWhenCustomPeriodIsIncomplete() throws Exception {
+    mockMvc.perform(get("/reports/general")
+        .param("period", "custom")
+        .param("endDate", "2024-03-31"))
+      .andExpect(status().isBadRequest());
   }
 }


### PR DESCRIPTION
## Summary
- extend report date range resolution to support 3-month, 1-month, and custom periods
- add controller tests covering the new period handling logic

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68d70b1fb5c48331add9d42442a6450a