### PR TITLE
Refine reports filters layout

### DIFF
--- a/anddes-onboarding-frontend/src/app/components/reports/reports.component.html
+++ b/anddes-onboarding-frontend/src/app/components/reports/reports.component.html
@@ -1,6 +1,17 @@
 <div class="reports-page">
-  <div class="filters">
-    <mat-form-field appearance="outline">
+  <div class="filters-header">
+    <button
+      mat-icon-button
+      color="primary"
+      class="download-button"
+      type="button"
+      aria-label="Descargar Excel"
+      (click)="downloadExcel()"
+    >
+      <mat-icon>file_download</mat-icon>
+    </button>
+
+    <mat-form-field class="borderless-field" appearance="fill">
       <mat-label>Tipo de reporte</mat-label>
       <mat-select [formControl]="typeControl">
         <mat-option *ngFor="let option of reportTypes" [value]="option.value">
@@ -9,7 +20,7 @@
       </mat-select>
     </mat-form-field>
 
-    <mat-form-field appearance="outline">
+    <mat-form-field class="borderless-field" appearance="fill">
       <mat-label>Periodo</mat-label>
       <mat-select [formControl]="periodControl">
         <mat-select-trigger>
@@ -21,7 +32,7 @@
       </mat-select>
     </mat-form-field>
 
-    <mat-form-field appearance="outline">
+    <mat-form-field class="borderless-field" appearance="fill">
       <mat-label>Estado</mat-label>
       <mat-select [formControl]="stateControl">
         <mat-option *ngFor="let option of stateOptions" [value]="option.value">
@@ -29,7 +40,9 @@
         </mat-option>
       </mat-select>
     </mat-form-field>
+  </div>
 
+  <div class="filters">
     <mat-form-field class="search-field" appearance="outline">
       <mat-label>Buscar por usuario</mat-label>
       <input matInput [formControl]="searchControl" placeholder="Nombre o correo" />
@@ -44,11 +57,6 @@
         <mat-icon>close</mat-icon>
       </button>
     </mat-form-field>
-
-    <button mat-stroked-button color="primary" class="download-button" type="button" (click)="downloadExcel()">
-      <mat-icon>file_download</mat-icon>
-      Descargar Excel
-    </button>
   </div>
 
   <mat-progress-bar *ngIf="isLoading" mode="indeterminate"></mat-progress-bar>

--- a/anddes-onboarding-frontend/src/app/components/reports/reports.component.scss
+++ b/anddes-onboarding-frontend/src/app/components/reports/reports.component.scss
@@ -4,24 +4,46 @@
   gap: 1.5rem;
 }
 
-.filters {
+.filters-header {
   display: flex;
   flex-wrap: wrap;
-  align-items: flex-end;
+  align-items: center;
   gap: 1rem;
 
   mat-form-field {
     min-width: 220px;
-  }
-
-  .search-field {
-    flex: 1 1 260px;
+    flex: 1 1 220px;
   }
 
   .download-button {
-    align-self: center;
-    display: inline-flex;
-    gap: 0.25rem;
+    align-self: flex-start;
+  }
+
+  .borderless-field.mat-mdc-form-field {
+    --mdc-filled-text-field-container-color: transparent;
+    --mdc-filled-text-field-focus-active-indicator-color: transparent;
+    --mdc-filled-text-field-active-indicator-color: transparent;
+    --mdc-filled-text-field-hover-active-indicator-color: transparent;
+    --mdc-filled-text-field-container-shape: 8px;
+
+    .mat-mdc-text-field-wrapper {
+      padding: 0;
+      background-color: transparent;
+    }
+
+    .mat-mdc-form-field-focus-overlay {
+      display: none;
+    }
+  }
+}
+
+.filters {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  .search-field {
+    width: 100%;
   }
 }
 
@@ -95,17 +117,12 @@ table {
 }
 
 @media (max-width: 900px) {
-  .filters {
+  .filters-header {
     flex-direction: column;
     align-items: stretch;
 
-    mat-form-field,
     .download-button {
-      width: 100%;
-    }
-
-    .download-button {
-      justify-content: center;
+      align-self: flex-start;
     }
   }
 


### PR DESCRIPTION
## Summary
- replace the reports download action with a leading icon-only button and rearrange the filter header
- switch report type, period, and state selects to a borderless look and align them on a single row
- update the reports filter styles so the icon button stays on top and the search field spans a dedicated full-width row

## Testing
- npx ng serve --host 0.0.0.0 --port 4200

------
https://chatgpt.com/codex/tasks/task_e_68d70c464ba88331bd86b015a9891dfe