### PR TITLE
Adjust report pagination to zero-based

### DIFF
--- a/anddes-onboarding-frontend/src/app/service/report.service.ts
+++ b/anddes-onboarding-frontend/src/app/service/report.service.ts
@@ -61,7 +61,7 @@ export class ReportService {
     let params = new HttpParams()
       .set('type', type)
       .set('state', query.state)
-      .set('page', query.pageIndex + 1)
+      .set('page', query.pageIndex)
       .set('pageSize', query.pageSize);
 
     if (query.search) {


### PR DESCRIPTION
## Summary
- send the current paginator index directly in report requests so the API receives zero-based pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d71f0c140c83318fa9bbe3ae0c178a