### PR TITLE
Update general report fields and UI

### DIFF
--- a/anddes-onboarding-frontend/src/app/components/reports/dialogs/general-detail-dialog.component.ts
+++ b/anddes-onboarding-frontend/src/app/components/reports/dialogs/general-detail-dialog.component.ts
@@ -8,7 +8,7 @@ import { ReportService } from '../../../service/report.service';
 import { ActivityDetail } from '../../../entity/report';
 
 export interface GeneralDetailDialogData {
-  userId: string;
+  processId: string;
   fullName: string;
 }
 
@@ -38,7 +38,7 @@ export class GeneralDetailDialogComponent implements OnInit {
   }
 
   private loadDetails(): void {
-    this.reportService.getGeneralDetail(this.data.userId).subscribe({
+    this.reportService.getGeneralDetail(this.data.processId).subscribe({
       next: (details) => {
         this.details = details;
         this.isLoading = false;

--- a/anddes-onboarding-frontend/src/app/components/reports/reports.component.html
+++ b/anddes-onboarding-frontend/src/app/components/reports/reports.component.html
@@ -71,32 +71,27 @@
       matSortDirection="asc"
       class="mat-elevation-z1"
     >
+      <ng-container matColumnDef="dni" *ngIf="isGeneral">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>DNI</th>
+        <td mat-cell *matCellDef="let row">{{ row.dni }}</td>
+      </ng-container>
+
       <ng-container matColumnDef="fullName">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Usuario</th>
         <td mat-cell *matCellDef="let row">{{ row.fullName }}</td>
       </ng-container>
 
-      <ng-container matColumnDef="position" *ngIf="isGeneral || isMatrix">
+      <ng-container matColumnDef="position" *ngIf="isMatrix">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Cargo</th>
         <td mat-cell *matCellDef="let row">{{ row.position }}</td>
       </ng-container>
 
-      <ng-container matColumnDef="bossName" *ngIf="isGeneral">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Jefe</th>
-        <td mat-cell *matCellDef="let row">{{ row.bossName }}</td>
-      </ng-container>
-
       <ng-container matColumnDef="progress" *ngIf="isGeneral">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Avance</th>
-        <td mat-cell *matCellDef="let row">
-          <div class="progress-cell">
-            <span class="progress-value">{{ row.progress | number: '1.0-0' }}%</span>
-            <span class="progress-label">{{ getProgressLabel(row) }}</span>
-          </div>
-        </td>
+        <td mat-cell *matCellDef="let row">{{ getProgressLabel(row) }}</td>
       </ng-container>
 
-      <ng-container matColumnDef="state" *ngIf="isGeneral || isElearning">
+      <ng-container matColumnDef="state" *ngIf="isElearning">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Estado</th>
         <td mat-cell *matCellDef="let row">
           <span [class]="stateClass(resolveState(row))">{{ stateLabel(resolveState(row)) }}</span>
@@ -106,6 +101,11 @@
       <ng-container matColumnDef="startDate" *ngIf="isGeneral">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Fecha de inicio</th>
         <td mat-cell *matCellDef="let row">{{ row.startDate | date: 'shortDate' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="finishDate" *ngIf="isGeneral">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Fecha de fin</th>
+        <td mat-cell *matCellDef="let row">{{ row.finishDate | date: 'shortDate' }}</td>
       </ng-container>
 
       <ng-container matColumnDef="totalCourses" *ngIf="isElearning">
@@ -165,7 +165,12 @@
       </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns" class="data-row"></tr>
+      <tr
+        mat-row
+        *matRowDef="let row; columns: displayedColumns"
+        class="data-row"
+        [ngClass]="{ 'delayed-row': row.delayed }"
+      ></tr>
       <tr class="mat-row" *matNoDataRow>
         <td class="no-data" [attr.colspan]="displayedColumns.length">No se encontraron resultados</td>
       </tr>

--- a/anddes-onboarding-frontend/src/app/components/reports/reports.component.scss
+++ b/anddes-onboarding-frontend/src/app/components/reports/reports.component.scss
@@ -58,21 +58,6 @@ table {
   width: 100%;
 }
 
-.progress-cell {
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
-
-  .progress-value {
-    font-weight: 600;
-  }
-
-  .progress-label {
-    font-size: 0.75rem;
-    color: #6b7280;
-  }
-}
-
 .actions-header,
 .actions-cell {
   text-align: right;
@@ -82,6 +67,11 @@ table {
   display: flex;
   justify-content: flex-end;
   gap: 0.75rem;
+}
+
+.delayed-row {
+  background-color: #fee2e2;
+  color: #991b1b;
 }
 
 .status-pill {

--- a/anddes-onboarding-frontend/src/app/components/reports/reports.component.ts
+++ b/anddes-onboarding-frontend/src/app/components/reports/reports.component.ts
@@ -197,7 +197,7 @@ export class ReportsComponent implements AfterViewInit {
   openGeneralDetail(row: any): void {
     const generalRow = row as GeneralReportRow;
     this.dialog.open(GeneralDetailDialogComponent, {
-      data: { userId: generalRow.id, fullName: generalRow.fullName },
+      data: { processId: generalRow.processId, fullName: generalRow.fullName },
     });
   }
 
@@ -252,7 +252,7 @@ export class ReportsComponent implements AfterViewInit {
   }
 
   resolveState(row: any): ReportRowState {
-    const value = (row as GeneralReportRow).state ?? (row as ElearningReportRow).state;
+    const value = (row as ElearningReportRow).state;
     return (value ?? 'pending') as ReportRowState;
   }
 
@@ -347,7 +347,7 @@ export class ReportsComponent implements AfterViewInit {
 
   private updateDisplayedColumns(type: ReportType): void {
     if (type === 'general') {
-      this.displayedColumns = ['fullName', 'position', 'bossName', 'progress', 'state', 'startDate', 'actions'];
+      this.displayedColumns = ['dni', 'fullName', 'startDate', 'finishDate', 'progress', 'actions'];
     } else if (type === 'elearning') {
       this.displayedColumns = ['fullName', 'totalCourses', 'approvedCourses', 'averageScore', 'state', 'updatedAt', 'actions'];
     } else {

--- a/anddes-onboarding-frontend/src/app/entity/report.ts
+++ b/anddes-onboarding-frontend/src/app/entity/report.ts
@@ -21,15 +21,15 @@ export interface PagedReportResponse<T> {
 export type ReportRowState = 'pending' | 'in_progress' | 'completed';
 
 export interface GeneralReportRow {
-  id: string;
+  processId: string;
+  dni: string;
   fullName: string;
-  position: string;
-  bossName: string;
   startDate: string;
-  progress: number;
-  state: ReportRowState;
+  finishDate: string;
   completedActivities: number;
   totalActivities: number;
+  progress: number;
+  delayed: boolean;
 }
 
 export interface ElearningReportRow {

--- a/anddes-onboarding-frontend/src/app/service/report.service.ts
+++ b/anddes-onboarding-frontend/src/app/service/report.service.ts
@@ -42,8 +42,8 @@ export class ReportService {
     );
   }
 
-  getGeneralDetail(userId: string): Observable<ActivityDetail[]> {
-    return this.httpClient.get<ActivityDetail[]>(`${this.baseUrl}/general/${userId}`);
+  getGeneralDetail(processId: string): Observable<ActivityDetail[]> {
+    return this.httpClient.get<ActivityDetail[]>(`${this.baseUrl}/general/${processId}`);
   }
 
   getElearningDetail(userId: string): Observable<ElearningDetail[]> {


### PR DESCRIPTION
## Summary
- align the general report row model with the new backend response including process and delay metadata
- refresh the general report table to show DNI, finish date, and delayed highlighting while simplifying the progress display
- update dialog and service calls to fetch general detail data by process identifier

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d747fd937083319b914441b02f18f2