### PR TITLE
Fix general report detail endpoint URL

### DIFF
--- a/anddes-onboarding-frontend/src/app/components/reports/dialogs/general-detail-dialog.component.ts
+++ b/anddes-onboarding-frontend/src/app/components/reports/dialogs/general-detail-dialog.component.ts
@@ -5,11 +5,12 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { ReportService } from '../../../service/report.service';
-import { ActivityDetail } from '../../../entity/report';
+import { ActivityDetail, ReportQuery } from '../../../entity/report';
 
 export interface GeneralDetailDialogData {
   processId: string;
   fullName: string;
+  query?: Partial<Omit<ReportQuery, 'pageIndex' | 'pageSize'>>;
 }
 
 @Component({
@@ -38,7 +39,7 @@ export class GeneralDetailDialogComponent implements OnInit {
   }
 
   private loadDetails(): void {
-    this.reportService.getGeneralDetail(this.data.processId).subscribe({
+    this.reportService.getGeneralDetail(this.data.processId, this.data.query).subscribe({
       next: (details) => {
         this.details = details;
         this.isLoading = false;

--- a/anddes-onboarding-frontend/src/app/components/reports/reports.component.ts
+++ b/anddes-onboarding-frontend/src/app/components/reports/reports.component.ts
@@ -197,7 +197,11 @@ export class ReportsComponent implements AfterViewInit {
   openGeneralDetail(row: any): void {
     const generalRow = row as GeneralReportRow;
     this.dialog.open(GeneralDetailDialogComponent, {
-      data: { processId: generalRow.processId, fullName: generalRow.fullName },
+      data: {
+        processId: generalRow.processId,
+        fullName: generalRow.fullName,
+        query: this.buildDetailQuery(),
+      },
     });
   }
 
@@ -304,6 +308,26 @@ export class ReportsComponent implements AfterViewInit {
       pageIndex: this.paginator?.pageIndex ?? 0,
       pageSize: this.paginator?.pageSize ?? 10,
     };
+  }
+
+  private buildDetailQuery(): Partial<Omit<ReportQuery, 'pageIndex' | 'pageSize'>> {
+    const { startDate, endDate } = this.resolveDates();
+    const direction = this.sort?.direction ? (this.sort.direction as 'asc' | 'desc') : undefined;
+
+    const query: Partial<Omit<ReportQuery, 'pageIndex' | 'pageSize'>> = {
+      state: this.stateControl.value,
+      search: this.searchControl.value?.trim() || undefined,
+      startDate,
+      endDate,
+      orderBy: this.sort?.active,
+      direction,
+    };
+
+    if (query.state === 'all') {
+      delete query.state;
+    }
+
+    return query;
   }
 
   private resolveDates(): { startDate?: string; endDate?: string } {

--- a/anddes-onboarding-frontend/src/app/service/report.service.ts
+++ b/anddes-onboarding-frontend/src/app/service/report.service.ts
@@ -42,8 +42,15 @@ export class ReportService {
     );
   }
 
-  getGeneralDetail(processId: string): Observable<ActivityDetail[]> {
-    return this.httpClient.get<ActivityDetail[]>(`${this.baseUrl}/general/${processId}`);
+  getGeneralDetail(
+    processId: string,
+    query?: Partial<Omit<ReportQuery, 'pageIndex' | 'pageSize'>>
+  ): Observable<ActivityDetail[]> {
+    const params = query ? this.buildDetailParams(query) : undefined;
+
+    return this.httpClient.get<ActivityDetail[]>(`${this.baseUrl}/general/${processId}/activities`, {
+      params,
+    });
   }
 
   getElearningDetail(userId: string): Observable<ElearningDetail[]> {
@@ -75,6 +82,36 @@ export class ReportService {
     if (query.orderBy) {
       params = params.set('orderBy', query.orderBy);
     }
+    if (query.direction) {
+      params = params.set('direction', query.direction);
+    }
+
+    return params;
+  }
+
+  private buildDetailParams(query: Partial<Omit<ReportQuery, 'pageIndex' | 'pageSize'>>): HttpParams {
+    let params = new HttpParams();
+
+    if (query.state) {
+      params = params.set('state', query.state);
+    }
+
+    if (query.search) {
+      params = params.set('search', query.search);
+    }
+
+    if (query.startDate) {
+      params = params.set('startDate', query.startDate);
+    }
+
+    if (query.endDate) {
+      params = params.set('endDate', query.endDate);
+    }
+
+    if (query.orderBy) {
+      params = params.set('orderBy', query.orderBy);
+    }
+
     if (query.direction) {
       params = params.set('direction', query.direction);
     }


### PR DESCRIPTION
## Summary
- update the general detail service to use the new /general/{processId}/activities API
- pass the current date, search and ordering filters when opening the detail dialog so they reach the backend
- adjust the dialog to accept the propagated filters

## Testing
- CI=1 npm test -- --watch=false --browsers=ChromeHeadless --progress=false *(fails: existing HomeComponent spec cannot resolve './HomeComponent')*

------
https://chatgpt.com/codex/tasks/task_e_68d75e1c1118833186b846fba9d1e677