### PR TITLE
Add parent code to report activity details

### DIFF
--- a/anddes-onboarding-backend/src/main/java/pe/compendio/myandess/onboarding/controller/dto/ReportActivityDetailDTO.java
+++ b/anddes-onboarding-backend/src/main/java/pe/compendio/myandess/onboarding/controller/dto/ReportActivityDetailDTO.java
@@ -17,4 +17,5 @@ public class ReportActivityDetailDTO {
   private boolean completed;
   private LocalDateTime completionDate;
   private String state;
+  private String parentCode;
 }

--- a/anddes-onboarding-backend/src/main/java/pe/compendio/myandess/onboarding/util/Mapper.java
+++ b/anddes-onboarding-backend/src/main/java/pe/compendio/myandess/onboarding/util/Mapper.java
@@ -162,6 +162,7 @@ public abstract class Mapper {
 
   @Mapping(target = "activityId", source = "id")
   @Mapping(target = "activityName", source = "activity.name")
+  @Mapping(target = "parentCode", source = "activity.parentCode")
   @Mapping(target = "state", ignore = true)
   public abstract ReportActivityDetailDTO processActivityToReportActivityDetail(ProcessActivity processActivity);
 

--- a/anddes-onboarding-frontend/src/app/components/reports/general-detail/general-detail.component.ts
+++ b/anddes-onboarding-frontend/src/app/components/reports/general-detail/general-detail.component.ts
@@ -27,17 +27,17 @@ type ActivitySection = {
 
 const SECTION_METADATA: Record<string, { title: string; description: string; icon: string }> = {
   BEFORE: {
-    title: 'Antes del ingreso',
+    title: 'Antes',
     description: 'Actividades previas al inicio del colaborador',
     icon: 'schedule',
   },
   FIRST_DAY: {
-    title: 'Primer día',
+    title: 'Mi primer día',
     description: 'Tareas esenciales para el primer día de trabajo',
     icon: 'calendar_month',
   },
   FIRST_WEEK: {
-    title: 'Primera semana',
+    title: 'Mi primera semana',
     description: 'Seguimiento y acompañamiento durante la primera semana',
     icon: 'view_week',
   },
@@ -190,7 +190,7 @@ export class GeneralDetailComponent implements OnInit, OnDestroy {
     const groups = new Map<string, ActivityDetail[]>();
 
     for (const detail of details) {
-      const key = (detail.state ?? detail.period ?? 'OTHER').toString().toUpperCase();
+      const key = (detail.parentCode ?? 'OTHER').toString().toUpperCase();
       if (!groups.has(key)) {
         groups.set(key, []);
       }

--- a/anddes-onboarding-frontend/src/app/entity/report.ts
+++ b/anddes-onboarding-frontend/src/app/entity/report.ts
@@ -61,6 +61,7 @@ export interface ActivityDetail {
   period?: string;
   activityName?: string;
   completionDate?: string;
+  parentCode?: string;
 }
 
 export interface ElearningDetail {


### PR DESCRIPTION
## Summary
- add parentCode to report activity detail DTO and mapStruct configuration
- expose parentCode in frontend activity detail model and regroup sections by the new code with updated labels

## Testing
- `./mvnw test` *(fails: Network is unreachable while downloading Maven wrapper distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68d7641db3c483318fd32bd787dba8eb