### PR TITLE
Simplify general detail activity view

### DIFF
--- a/anddes-onboarding-frontend/src/app/components/reports/general-detail/general-detail.component.html
+++ b/anddes-onboarding-frontend/src/app/components/reports/general-detail/general-detail.component.html
@@ -27,39 +27,10 @@
   </section>
 
   <div class="detail-content" *ngIf="!isLoading && !hasError && details.length > 0">
-    <div class="summary-grid">
-      <div class="summary-card pending">
-        <mat-icon>pending_actions</mat-icon>
-        <div>
-          <h3>{{ pendingDetails.length }}</h3>
-          <p>Pendientes</p>
-        </div>
-      </div>
-      <div class="summary-card completed">
-        <mat-icon>check_circle</mat-icon>
-        <div>
-          <h3>{{ completedDetails.length }}</h3>
-          <p>Completadas</p>
-        </div>
-      </div>
-      <div class="summary-card total">
-        <mat-icon>assignment</mat-icon>
-        <div>
-          <h3>{{ details.length }}</h3>
-          <p>Total de actividades</p>
-        </div>
-      </div>
-    </div>
-
     <section class="activity-section" *ngFor="let section of sections; trackBy: trackBySection">
       <div class="section-header">
-        <div class="section-icon">
-          <mat-icon>{{ section.icon }}</mat-icon>
-        </div>
-        <div class="section-info">
-          <h2>{{ section.title }}</h2>
-          <p>{{ section.description }}</p>
-        </div>
+        <mat-icon class="section-icon">{{ section.icon }}</mat-icon>
+        <h2 class="section-title">{{ section.title }}</h2>
       </div>
 
       <ul class="activity-list">
@@ -68,17 +39,10 @@
           *ngFor="let activity of section.activities; trackBy: trackByActivity"
           [class.completed]="activity.completed"
         >
-          <div class="status-icon" [class.completed]="activity.completed">
-            <mat-icon>{{ activity.completed ? 'check_circle' : 'radio_button_unchecked' }}</mat-icon>
-          </div>
-          <div class="activity-info">
-            <h3 class="activity-title">{{ activity.title || activity.activityName }}</h3>
-            <p class="activity-meta" *ngIf="activity.responsible">Responsable: {{ activity.responsible }}</p>
-            <p class="activity-meta" *ngIf="!activity.completed">Estado: Pendiente</p>
-            <p class="activity-meta" *ngIf="activity.completed">
-              Completada el {{ (activity.completedAt || activity.completionDate) | date: 'shortDate' }}
-            </p>
-          </div>
+          <mat-icon class="status-icon" [class.completed]="activity.completed">
+            {{ activity.completed ? 'check_circle' : 'radio_button_unchecked' }}
+          </mat-icon>
+          <h3 class="activity-title">{{ activity.title || activity.activityName }}</h3>
         </li>
       </ul>
     </section>

--- a/anddes-onboarding-frontend/src/app/components/reports/general-detail/general-detail.component.scss
+++ b/anddes-onboarding-frontend/src/app/components/reports/general-detail/general-detail.component.scss
@@ -73,89 +73,34 @@
 .detail-content {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
-}
-
-.summary-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 1rem;
-}
-
-.summary-card {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 1.25rem;
-  border-radius: 16px;
-  background: #fff;
-  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
-}
-
-.summary-card mat-icon {
-  font-size: 32px;
-}
-
-.summary-card h3 {
-  margin: 0;
-  font-size: 1.75rem;
-  color: #0f172a;
-}
-
-.summary-card p {
-  margin: 0;
-  color: #64748b;
-}
-
-.summary-card.pending mat-icon {
-  color: #f97316;
-}
-
-.summary-card.completed mat-icon {
-  color: #10b981;
-}
-
-.summary-card.total mat-icon {
-  color: #1d4ed8;
+  gap: 1.75rem;
 }
 
 .activity-section {
-  background: #fff;
-  border-radius: 20px;
-  padding: 1.75rem;
-  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: 16px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
 }
 
 .section-header {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .section-icon {
-  width: 48px;
-  height: 48px;
-  border-radius: 12px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: linear-gradient(135deg, #1d4ed8, #3b82f6);
-  color: #fff;
-  box-shadow: 0 8px 24px rgba(59, 130, 246, 0.3);
+  font-size: 28px;
+  color: #1d4ed8;
 }
 
-.section-info h2 {
+.section-title {
   margin: 0;
-  font-size: 1.4rem;
+  font-size: 1.3rem;
   color: #0f172a;
-}
-
-.section-info p {
-  margin: 0;
-  color: #64748b;
 }
 
 .activity-list {
@@ -164,71 +109,50 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .activity-item {
   display: flex;
-  gap: 1rem;
-  padding: 1.1rem;
-  border-radius: 16px;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
   border: 1px solid #e2e8f0;
   background: #f8fafc;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.activity-item:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
 }
 
 .activity-item.completed {
   border-color: #bbf7d0;
-  background: #ecfdf5;
+  background: #f1f5f9;
 }
 
 .status-icon {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  background: #e2e8f0;
-  color: #1e293b;
+  font-size: 22px;
+  color: #64748b;
 }
 
 .status-icon.completed {
-  background: #dcfce7;
   color: #16a34a;
-}
-
-.activity-info {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
 }
 
 .activity-title {
   margin: 0;
-  font-size: 1.05rem;
+  font-size: 1rem;
   font-weight: 600;
   color: #0f172a;
 }
 
-.activity-meta {
-  margin: 0;
-  color: #64748b;
-  font-size: 0.9rem;
+.activity-item.completed .activity-title {
+  color: #166534;
 }
 
 @media (max-width: 768px) {
   .general-detail-page {
     padding: 1.5rem 1rem;
-  }
-
-  .summary-grid {
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   }
 
   .activity-section {

--- a/anddes-onboarding-frontend/src/app/components/reports/general-detail/general-detail.component.ts
+++ b/anddes-onboarding-frontend/src/app/components/reports/general-detail/general-detail.component.ts
@@ -20,25 +20,21 @@ type DetailQuery = Partial<Omit<ReportQuery, 'pageIndex' | 'pageSize'>>;
 type ActivitySection = {
   key: string;
   title: string;
-  description: string;
   icon: string;
   activities: ActivityDetail[];
 };
 
-const SECTION_METADATA: Record<string, { title: string; description: string; icon: string }> = {
+const SECTION_METADATA: Record<string, { title: string; icon: string }> = {
   BEFORE: {
     title: 'Antes',
-    description: 'Actividades previas al inicio del colaborador',
     icon: 'schedule',
   },
   FIRST_DAY: {
     title: 'Mi primer día',
-    description: 'Tareas esenciales para el primer día de trabajo',
     icon: 'calendar_month',
   },
   FIRST_WEEK: {
     title: 'Mi primera semana',
-    description: 'Seguimiento y acompañamiento durante la primera semana',
     icon: 'view_week',
   },
 };
@@ -56,8 +52,6 @@ const SECTION_ORDER = ['BEFORE', 'FIRST_DAY', 'FIRST_WEEK'];
 export class GeneralDetailComponent implements OnInit, OnDestroy {
   sections: ActivitySection[] = [];
   details: ActivityDetail[] = [];
-  pendingDetails: ActivityDetail[] = [];
-  completedDetails: ActivityDetail[] = [];
 
   isLoading = true;
   hasError = false;
@@ -98,8 +92,6 @@ export class GeneralDetailComponent implements OnInit, OnDestroy {
             this.hasError = true;
             this.details = [];
             this.sections = [];
-            this.pendingDetails = [];
-            this.completedDetails = [];
             this.cdr.markForCheck();
             return EMPTY;
           }
@@ -110,8 +102,6 @@ export class GeneralDetailComponent implements OnInit, OnDestroy {
       .subscribe({
         next: (details) => {
           this.details = details;
-          this.pendingDetails = details.filter((detail) => !detail.completed);
-          this.completedDetails = details.filter((detail) => detail.completed);
           this.sections = this.buildSections(details);
           this.isLoading = false;
           this.hasError = false;
@@ -119,8 +109,6 @@ export class GeneralDetailComponent implements OnInit, OnDestroy {
         },
         error: () => {
           this.details = [];
-          this.pendingDetails = [];
-          this.completedDetails = [];
           this.sections = [];
           this.isLoading = false;
           this.hasError = true;
@@ -200,7 +188,6 @@ export class GeneralDetailComponent implements OnInit, OnDestroy {
     const sections = Array.from(groups.entries()).map(([key, activities]) => {
       const metadata = SECTION_METADATA[key] ?? {
         title: 'Otras actividades',
-        description: 'Actividades adicionales del proceso de onboarding',
         icon: 'task_alt',
       };
 
@@ -218,7 +205,6 @@ export class GeneralDetailComponent implements OnInit, OnDestroy {
       return {
         key,
         title: metadata.title,
-        description: metadata.description,
         icon: metadata.icon,
         activities: sortedActivities,
       } satisfies ActivitySection;


### PR DESCRIPTION
## Summary
- streamline the general detail report view to display only section headers and a completion icon with the activity name
- adjust the component data model to provide simplified section metadata for the new layout
- clean up the component stylesheet to match the reduced markup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d76545f5a883319c0e9df6dc0ffe36