### PR TITLE
Remove date filtering from general activity details

### DIFF
--- a/anddes-onboarding-backend/src/main/java/pe/compendio/myandess/onboarding/controller/ReportController.java
+++ b/anddes-onboarding-backend/src/main/java/pe/compendio/myandess/onboarding/controller/ReportController.java
@@ -95,8 +95,7 @@ public class ReportController {
                                                          @RequestParam(required = false) String search,
                                                          @RequestParam(defaultValue = "activityName") String orderBy,
                                                          @RequestParam(defaultValue = "asc") String direction) {
-    DateRange range = resolveDateRange(startDate, endDate, period);
-    return reportService.getGeneralDetails(processId, range.start(), range.end(), state, search, orderBy, direction);
+    return reportService.getGeneralDetails(processId, state, search, orderBy, direction);
   }
 
   @Operation(summary = "Detalle de cursos e-learning del proceso")

--- a/anddes-onboarding-backend/src/main/java/pe/compendio/myandess/onboarding/service/ReportService.java
+++ b/anddes-onboarding-backend/src/main/java/pe/compendio/myandess/onboarding/service/ReportService.java
@@ -155,8 +155,6 @@ public class ReportService {
   }
 
   public List<ReportActivityDetailDTO> getGeneralDetails(Long processId,
-                                                         LocalDate startDate,
-                                                         LocalDate endDate,
                                                          String state,
                                                          String search,
                                                          String orderBy,
@@ -164,16 +162,6 @@ public class ReportService {
     List<ProcessActivity> activities = processActivityRepository.findByProcess_Id(processId);
     List<ReportActivityDetailDTO> details = mapper.processActivitiesToReportActivityDetails(activities);
     details.forEach(detail -> detail.setState(detail.isCompleted() ? STATE_COMPLETED : STATE_PENDING));
-
-    if (startDate != null || endDate != null) {
-      LocalDateTime startBound = startDate != null ? startDate.atStartOfDay() : LocalDateTime.MIN;
-      LocalDateTime endBound = endDate != null ? endDate.atTime(23, 59, 59) : LocalDateTime.MAX;
-      details = details.stream()
-        .filter(detail -> detail.getCompletionDate() != null
-          && !detail.getCompletionDate().isBefore(startBound)
-          && !detail.getCompletionDate().isAfter(endBound))
-        .collect(Collectors.toList());
-    }
 
     String normalizedState = normalizeState(state);
     if (StringUtils.hasText(normalizedState) && !"ALL".equals(normalizedState)) {

--- a/anddes-onboarding-backend/src/test/java/pe/compendio/myandess/onboarding/service/ReportServiceTest.java
+++ b/anddes-onboarding-backend/src/test/java/pe/compendio/myandess/onboarding/service/ReportServiceTest.java
@@ -207,12 +207,17 @@ class ReportServiceTest {
   }
 
   @Test
-  void shouldFilterGeneralDetailsByStateAndDate() {
-    List<ReportActivityDetailDTO> details = reportService.getGeneralDetails(process.getId(),
-      LocalDate.of(2024, 1, 11), LocalDate.of(2024, 1, 13), "COMPLETADO", null, "activityName", "asc");
+  void shouldFilterGeneralDetailsByStateAndReturnAllWithoutDateFilter() {
+    List<ReportActivityDetailDTO> allDetails = reportService.getGeneralDetails(process.getId(),
+      null, null, "activityName", "asc");
+    List<ReportActivityDetailDTO> completedDetails = reportService.getGeneralDetails(process.getId(),
+      "COMPLETADO", null, "activityName", "asc");
 
-    assertThat(details).hasSize(1);
-    assertThat(details.get(0).getState()).isEqualTo("Completado");
+    assertThat(allDetails).hasSize(3);
+    assertThat(allDetails).extracting(ReportActivityDetailDTO::getState)
+      .containsExactlyInAnyOrder("Completado", "Pendiente", "Pendiente");
+    assertThat(completedDetails).hasSize(1);
+    assertThat(completedDetails.get(0).getState()).isEqualTo("Completado");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- stop resolving date ranges for the general details endpoint and forward null date filters
- simplify ReportService#getGeneralDetails by removing date filtering and keeping state/search ordering only
- refresh the service unit test to cover state filtering and ensure all activities are returned when no state filter is applied

## Testing
- `bash mvnw test` *(fails: java.net.SocketException Network is unreachable while downloading Maven wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d766de621483318db63930a67a6b29