### PR TITLE
Remove filtering from general activity details

### DIFF
--- a/anddes-onboarding-backend/src/main/java/pe/compendio/myandess/onboarding/service/ReportService.java
+++ b/anddes-onboarding-backend/src/main/java/pe/compendio/myandess/onboarding/service/ReportService.java
@@ -162,22 +162,6 @@ public class ReportService {
     List<ProcessActivity> activities = processActivityRepository.findByProcess_Id(processId);
     List<ReportActivityDetailDTO> details = mapper.processActivitiesToReportActivityDetails(activities);
     details.forEach(detail -> detail.setState(detail.isCompleted() ? STATE_COMPLETED : STATE_PENDING));
-
-    String normalizedState = normalizeState(state);
-    if (StringUtils.hasText(normalizedState) && !"ALL".equals(normalizedState)) {
-      details = details.stream()
-        .filter(detail -> filterByState(detail.getState(), normalizedState))
-        .collect(Collectors.toList());
-    }
-
-    if (StringUtils.hasText(search)) {
-      String lower = search.toLowerCase(Locale.getDefault());
-      details = details.stream()
-        .filter(detail -> detail.getActivityName() != null && detail.getActivityName().toLowerCase(Locale.getDefault()).contains(lower))
-        .collect(Collectors.toList());
-    }
-
-    details.sort(buildActivityDetailComparator(orderBy, direction));
     return details;
   }
 

--- a/anddes-onboarding-backend/src/test/java/pe/compendio/myandess/onboarding/service/ReportServiceTest.java
+++ b/anddes-onboarding-backend/src/test/java/pe/compendio/myandess/onboarding/service/ReportServiceTest.java
@@ -207,17 +207,13 @@ class ReportServiceTest {
   }
 
   @Test
-  void shouldFilterGeneralDetailsByStateAndReturnAllWithoutDateFilter() {
-    List<ReportActivityDetailDTO> allDetails = reportService.getGeneralDetails(process.getId(),
+  void shouldReturnGeneralDetailsWithCalculatedStates() {
+    List<ReportActivityDetailDTO> details = reportService.getGeneralDetails(process.getId(),
       null, null, "activityName", "asc");
-    List<ReportActivityDetailDTO> completedDetails = reportService.getGeneralDetails(process.getId(),
-      "COMPLETADO", null, "activityName", "asc");
 
-    assertThat(allDetails).hasSize(3);
-    assertThat(allDetails).extracting(ReportActivityDetailDTO::getState)
+    assertThat(details).hasSize(3);
+    assertThat(details).extracting(ReportActivityDetailDTO::getState)
       .containsExactlyInAnyOrder("Completado", "Pendiente", "Pendiente");
-    assertThat(completedDetails).hasSize(1);
-    assertThat(completedDetails.get(0).getState()).isEqualTo("Completado");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- return general activity details without applying filtering or sorting in the service layer
- update the report service unit test to assert only the calculated activity states

## Testing
- mvn -DskipITs test

------
https://chatgpt.com/codex/tasks/task_e_68d768b1f85083318cf0efb99cf82ac2