### PR TITLE
Refine e-learning report fields

### DIFF
--- a/anddes-onboarding-backend/src/main/java/pe/compendio/myandess/onboarding/controller/dto/ReportElearningRowDTO.java
+++ b/anddes-onboarding-backend/src/main/java/pe/compendio/myandess/onboarding/controller/dto/ReportElearningRowDTO.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Data
@@ -13,12 +14,10 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class ReportElearningRowDTO {
   private Long processId;
-  private String collaborator;
-  private int totalCourses;
-  private int completedCourses;
-  private double progress;
-  private long readCards;
-  private long correctAnswers;
-  private String state;
+  private String dni;
+  private String fullName;
+  private LocalDate startDate;
   private LocalDateTime finishDate;
+  private double progress;
+  private String state;
 }


### PR DESCRIPTION
## Summary
- update `ReportElearningRowDTO` to expose DNI, collaborator name, dates, progress, and state
- recalculate e-learning progress/state in `ReportService`, update sorting/export, and drop obsolete counters
- refresh controller and service tests to cover the new DTO contract and workbook headers

## Testing
- ./mvnw -q test *(fails: network unreachable while downloading Maven Wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d76c196d1083318eeca3718f475ad4