### PR TITLE
Simplify e-learning detail retrieval

### DIFF
--- a/anddes-onboarding-backend/src/main/java/pe/compendio/myandess/onboarding/controller/ReportController.java
+++ b/anddes-onboarding-backend/src/main/java/pe/compendio/myandess/onboarding/controller/ReportController.java
@@ -100,16 +100,8 @@ public class ReportController {
 
   @Operation(summary = "Detalle de cursos e-learning del proceso")
   @GetMapping("/elearning/{processId}/courses")
-  public List<ReportElearningDetailDTO> getElearningDetails(@PathVariable Long processId,
-                                                            @RequestParam(required = false) String startDate,
-                                                            @RequestParam(required = false) String endDate,
-                                                            @RequestParam(required = false) String period,
-                                                            @RequestParam(required = false) String state,
-                                                            @RequestParam(required = false) String search,
-                                                            @RequestParam(defaultValue = "courseName") String orderBy,
-                                                            @RequestParam(defaultValue = "asc") String direction) {
-    DateRange range = resolveDateRange(startDate, endDate, period);
-    return reportService.getElearningDetails(processId, range.start(), range.end(), state, search, orderBy, direction);
+  public List<ReportElearningDetailDTO> getElearningDetails(@PathVariable Long processId) {
+    return reportService.getElearningDetails(processId);
   }
 
   @Operation(summary = "Descargar reporte en Excel")

--- a/anddes-onboarding-backend/src/test/java/pe/compendio/myandess/onboarding/controller/ReportControllerTest.java
+++ b/anddes-onboarding-backend/src/test/java/pe/compendio/myandess/onboarding/controller/ReportControllerTest.java
@@ -107,7 +107,7 @@ class ReportControllerTest {
       .courseName("Seguridad")
       .state("Pendiente")
       .build();
-    when(reportService.getElearningDetails(anyLong(), any(LocalDate.class), any(LocalDate.class), nullable(String.class), nullable(String.class), anyString(), anyString()))
+    when(reportService.getElearningDetails(anyLong()))
       .thenReturn(List.of(detail));
 
     mockMvc.perform(get("/reports/elearning/1/courses"))

--- a/anddes-onboarding-backend/src/test/java/pe/compendio/myandess/onboarding/service/ReportServiceTest.java
+++ b/anddes-onboarding-backend/src/test/java/pe/compendio/myandess/onboarding/service/ReportServiceTest.java
@@ -235,11 +235,12 @@ class ReportServiceTest {
 
   @Test
   void shouldReturnElearningDetails() {
-    List<ReportElearningDetailDTO> details = reportService.getElearningDetails(process.getId(),
-      LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), "", null, "courseName", "asc");
+    List<ReportElearningDetailDTO> details = reportService.getElearningDetails(process.getId());
 
     assertThat(details).hasSize(2);
-    assertThat(details.get(0).getState()).isIn("Desaprobado", "Pendiente");
+    assertThat(details)
+      .extracting(ReportElearningDetailDTO::getState)
+      .containsExactlyInAnyOrder("Desaprobado", "Pendiente");
   }
 
   @Test

--- a/anddes-onboarding-frontend/src/app/components/reports/elearning-detail/elearning-detail.component.ts
+++ b/anddes-onboarding-frontend/src/app/components/reports/elearning-detail/elearning-detail.component.ts
@@ -10,13 +10,11 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatTableModule } from '@angular/material/table';
-import { ActivatedRoute, ParamMap } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { EMPTY, Subject, combineLatest } from 'rxjs';
 import { startWith, switchMap, takeUntil, tap } from 'rxjs/operators';
-import { ElearningDetail, ReportQuery } from '../../../entity/report';
+import { ElearningDetail } from '../../../entity/report';
 import { ReportService } from '../../../service/report.service';
-
-export type DetailQuery = Partial<Omit<ReportQuery, 'pageIndex' | 'pageSize'>>;
 
 @Component({
   selector: 'app-elearning-detail',
@@ -35,7 +33,6 @@ export class ElearningDetailComponent implements OnInit, OnDestroy {
   fullName = '';
 
   private processId: string | null = null;
-  private currentQuery: DetailQuery | undefined;
   private readonly destroy$ = new Subject<void>();
   private readonly reload$ = new Subject<void>();
 
@@ -62,7 +59,6 @@ export class ElearningDetailComponent implements OnInit, OnDestroy {
         switchMap(([params, queryParams]) => {
           this.processId = params.get('processId');
           this.fullName = queryParams.get('fullName') ?? '';
-          this.currentQuery = this.buildQueryFromParams(queryParams);
 
           if (!this.processId) {
             this.isLoading = false;
@@ -72,7 +68,7 @@ export class ElearningDetailComponent implements OnInit, OnDestroy {
             return EMPTY;
           }
 
-          return this.reportService.getElearningDetail(this.processId, this.currentQuery);
+          return this.reportService.getElearningDetail(this.processId);
         })
       )
       .subscribe({
@@ -118,41 +114,5 @@ export class ElearningDetailComponent implements OnInit, OnDestroy {
     }
 
     return 'Desaprobado';
-  }
-
-  private buildQueryFromParams(queryParams: ParamMap): DetailQuery | undefined {
-    const query: DetailQuery = {};
-
-    const state = queryParams.get('state');
-    if (state && state !== 'all') {
-      query.state = state as DetailQuery['state'];
-    }
-
-    const search = queryParams.get('search');
-    if (search) {
-      query.search = search;
-    }
-
-    const startDate = queryParams.get('startDate');
-    if (startDate) {
-      query.startDate = startDate;
-    }
-
-    const endDate = queryParams.get('endDate');
-    if (endDate) {
-      query.endDate = endDate;
-    }
-
-    const orderBy = queryParams.get('orderBy');
-    if (orderBy) {
-      query.orderBy = orderBy;
-    }
-
-    const direction = queryParams.get('direction');
-    if (direction === 'asc' || direction === 'desc') {
-      query.direction = direction;
-    }
-
-    return Object.keys(query).length > 0 ? query : undefined;
   }
 }

--- a/anddes-onboarding-frontend/src/app/service/report.service.ts
+++ b/anddes-onboarding-frontend/src/app/service/report.service.ts
@@ -69,40 +69,22 @@ export class ReportService {
     });
   }
 
-  getElearningDetail(
-    processId: string,
-    query?: Partial<Omit<ReportQuery, 'pageIndex' | 'pageSize'>>
-  ): Observable<ElearningDetail[]> {
-    const params = query ? this.buildDetailParams(query) : undefined;
+  getElearningDetail(processId: string): Observable<ElearningDetail[]> {
     return this.httpClient
-      .get<ElearningDetail[]>(`${this.baseUrl}/elearning/${processId}/courses`, {
-        params,
-      })
+      .get<ElearningDetail[]>(`${this.baseUrl}/elearning/${processId}/courses`)
       .pipe(
         map((details) =>
-          details.map((detail) => {
-            const minimumScore = detail.minimumScore ?? 0;
-            const rawResult = detail.result;
-            const result = rawResult != null ? rawResult : undefined;
-            const hasResult = rawResult != null;
-            const derivedState: ReportRowState = hasResult
-              ? rawResult >= minimumScore
-                ? 'Aprobado'
-                : 'Desaprobado'
-              : 'Desaprobado';
-
-            return {
-              contentId: detail.contentId != null ? String(detail.contentId) : '',
-              courseName: detail.courseName ?? '',
-              result,
-              minimumScore,
-              attempts: detail.attempts ?? 0,
-              progress: detail.progress ?? 0,
-              readCards: detail.readCards ?? 0,
-              correctAnswers: detail.correctAnswers ?? 0,
-              state: derivedState,
-            };
-          })
+          details.map((detail) => ({
+            contentId: detail.contentId != null ? String(detail.contentId) : '',
+            courseName: detail.courseName ?? '',
+            result: detail.result ?? undefined,
+            minimumScore: detail.minimumScore ?? 0,
+            attempts: detail.attempts ?? 0,
+            progress: detail.progress ?? 0,
+            readCards: detail.readCards ?? 0,
+            correctAnswers: detail.correctAnswers ?? 0,
+            state: (detail.state ?? 'Pendiente') as ReportRowState,
+          }))
         )
       );
   }


### PR DESCRIPTION
## Summary
- simplify the e-learning detail controller endpoint to forward only the process identifier
- adjust the report service and unit tests to drop unused filters while keeping course state calculation
- update the Angular client to stop sending detail filters and trust the backend-provided state

## Testing
- `sh mvnw test` *(fails: Maven wrapper cannot download dependencies without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68d778d199e883319ca0dd0728bb5e8e